### PR TITLE
fix: manually set errors prototype to make instanceof working

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,14 @@ export interface Crosshair {
 export class InvalidShareCode extends Error {
   public constructor() {
     super('Invalid share code');
+    Object.setPrototypeOf(this, InvalidShareCode.prototype);
   }
 }
 
 export class InvalidCrosshairShareCode extends Error {
   public constructor() {
     super('Invalid crosshair share code');
+    Object.setPrototypeOf(this, InvalidCrosshairShareCode.prototype);
   }
 }
 


### PR DESCRIPTION
https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work