### PR TITLE
Wrap creation of package.json script in ///

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "src/index.ts"
   ],
   "scripts": {
-    "build:cjs": "tsc --module CommonJS --outDir dist/cjs && echo { \"type\": \"commonjs\" } > ./dist/cjs/package.json",
+    "build:cjs": "tsc --module CommonJS --outDir dist/cjs && echo { \"\\\"type\"\\\": \"\\\"commonjs\"\\\" } > ./dist/cjs/package.json",
     "build:esm": "tsc  --module NodeNext --outDir dist/esm",
     "build:types": "tsc --emitDeclarationOnly --declaration --removeComments false",
     "build": "npm run build:esm && npm run build:cjs && npm run build:types",


### PR DESCRIPTION
There is an issue with the creation of the package.json for the CJS module.
When importing it the following error is thrown:
```SyntaxError: Error parsing /Users/philliplakis/Documents/GitHub/allstar-graphql-data/node_modules/csgo-sharecode/dist/cjs/package.json: Expected property name or '}' in JSON at position 2```


Steps to reproduce:
```bash
yarn add csgo-sharecodes
```
New TS file:
```TS
// # sharecode.ts
import { decodeMatchShareCode } from "csgo-sharecode";

export const SharecodeValidator = (sharecode: string) => {
  try {
    console.log(`sharecode:`, sharecode);
    const matchInformation = decodeMatchShareCode(sharecode);
    console.log(matchInformation);
    return sharecode;
  } catch {
    console.log("Invalid Sharecode");
    return false;
  }
};
```

```BASH
npx ts-node ./sharecode.ts
```

this is due to the package.json being written without quotes in the `./dist/cjs/package.json`
```JSON
{ type: commonjs }
```

The changes I made are in the script of the package on the `build:cjs` 

```
"build:cjs": "tsc --module CommonJS --outDir dist/cjs && echo { \"\\\"type\"\\\": \"\\\"commonjs\"\\\" } > ./dist/cjs/package.json",
```

this outputs the correct format for the package.json
```JSON
{ "type": "commonjs" }

```